### PR TITLE
Few fixes for CMake install directory and SONAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set( INSTALL_INCLUDE_DIR include CACHE PATH "Install directory for public header
 if( WIN32 AND NOT CYGWIN )
   set(DEF_INSTALL_CMAKE_DIR CMake)
 else()
-  set(DEF_INSTALL_CMAKE_DIR lib/CMake/AcesContainer)
+  set(DEF_INSTALL_CMAKE_DIR lib${LIB_SUFFIX}/CMake/AcesContainer)
 endif()
 set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Install directory for project CMake files" )
 
@@ -82,7 +82,13 @@ add_library( AcesContainer SHARED
 	aces_md5.cc
 )
 
-install (TARGETS AcesContainer EXPORT AcesContainerTargets DESTINATION ${INSTALL_LIB_DIR})
+# Set the build version (VERSION) and the API version (SOVERSION)
+SET_TARGET_PROPERTIES(AcesContainer
+                      PROPERTIES
+                      VERSION ${AcesContainer_VERSION}
+                      SOVERSION ${AcesContainer_MAJOR_VERSION})
+
+install (TARGETS AcesContainer EXPORT AcesContainerTargets DESTINATION ${LIB_INSTALL_DIR})
 install (FILES 
 			aces_errors.h
 			aces_genericWriter.h
@@ -97,14 +103,14 @@ install (FILES
 			aces_types.h
 			aces_writeattributes.h
 		 DESTINATION 
-		 	${INSTALL_INCLUDE_DIR}/aces
+                       ${INCLUDE_INSTALL_DIR}/aces
 		 )
 
 
 find_package( PkgConfig )
 if ( PKG_CONFIG_FOUND )
 configure_file(config/AcesContainer.pc.in "${PROJECT_BINARY_DIR}/AcesContainer.pc" @ONLY)
-install( FILES "${PROJECT_BINARY_DIR}/AcesContainer.pc" DESTINATION lib/pkgconfig COMPONENT dev )
+install( FILES "${PROJECT_BINARY_DIR}/AcesContainer.pc" DESTINATION lib${LIB_SUFFIX}/pkgconfig COMPONENT dev )
 endif()
 
 include_directories(

--- a/config/AcesContainer.pc.in
+++ b/config/AcesContainer.pc.in
@@ -45,7 +45,7 @@
 # A.M.P.A.S., WHETHER DISCLOSED OR UNDISCLOSED.
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@INSTALL_LIB_DIR@
+libdir=@LIB_INSTALL_DIR@
 includedir=@INSTALL_INCLUDE_DIR@
 AcesContainer_includedir=@INSTALL_INCLUDE_DIR@/aces
 

--- a/config/AcesContainerConfig.cmake.in
+++ b/config/AcesContainerConfig.cmake.in
@@ -53,10 +53,10 @@
 # find paths
 get_filename_component( AcesContainer_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH )
 
-set(AcesContainer_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(AcesContainer_INCLUDE_DIRS "@INCLUDE_INSTALL_DIR@")
 
 set(AcesContainer_LIBRARIES AcesContainer )
-set(AcesContainer_LIBRARY_DIRS "@CONF_LIB_DIRS@" )
+set(AcesContainer_LIBRARY_DIRS "@LIB_INSTALL_DIR@" )
 set(AcesContainer_VERSION "@AcesContainer_VERSION@" )
 
 set(AcesContainer_FOUND 1 )


### PR DESCRIPTION
This patch adds the appropriate properties for building the library on Linux.
It also fix some Cmake directory best suitable for the related files at install time.
Also fixed the use of LIB_SUFFIX that will allow to install into the appropriate ISA sub-directory (/usr/lib /usr/lib64 /usr/lib32, /usr/libx32). 

This patch was only tested on Linux (Fedora 19->22) on x86 x86_64 and armhfp.
